### PR TITLE
Added Yaru-MATE-dark and Yaru-MATE-light

### DIFF
--- a/src/buttons.cc
+++ b/src/buttons.cc
@@ -154,6 +154,8 @@ ColorButton::is_force_needed ()
 		"Yaru",
 		"Yaru-dark",
 		"Yaru-light",
+		"Yaru-MATE-dark",
+		"Yaru-MATE-light",
 		NULL
 	};
 


### PR DESCRIPTION
Added support for Ubuntu MATE specific themes.
Note: was inspired by this discussion - https://ubuntu-mate.community/t/yaru-and-gelemental-missing-colors/24558 .